### PR TITLE
Support for single global changes feed

### DIFF
--- a/backbone-couchdb.coffee
+++ b/backbone-couchdb.coffee
@@ -31,8 +31,17 @@ Backbone.couch_connector = con =
       # jquery.couch.js adds the id itself, so we delete the id if it is in the url.
       # "collection/:id" -> "collection"
       _splitted = _name.split "/"
-      _name = if _splitted.length > 0 then _splitted[0] else _name
-      _name = _name.replace "/", ""
+
+      # only pop off the last component if it is the id
+      if (_splitted.length > 0)
+        if (model.id == _splitted[_splitted.length - 1])
+          _splitted.pop()
+        _name = _splitted.join('/')
+
+      # remove any leading slash
+      if (_name.indexOf("/") == 0)
+        _name = _name.replace("/", "")
+
       _name
     
     # creates a database instance from the 

--- a/backbone-couchdb.js
+++ b/backbone-couchdb.js
@@ -1,9 +1,10 @@
 (function() {
   /*
   (c) 2011 Jan Monschke
-  v1.0
+  v1.1
   backbone-couchdb.js is licensed under the MIT license.
-  */  var con;
+  */
+  var con;
   var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; }, __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) {
     for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; }
     function ctor() { this.constructor = child; }
@@ -38,8 +39,15 @@
           _name = _name.slice(1, _name.length);
         }
         _splitted = _name.split("/");
-        _name = _splitted.length > 0 ? _splitted[0] : _name;
-        _name = _name.replace("/", "");
+        if (_splitted.length > 0) {
+          if (model.id === _splitted[_splitted.length - 1]) {
+            _splitted.pop();
+          }
+          _name = _splitted.join('/');
+        }
+        if (_name.indexOf("/") === 0) {
+          _name = _name.replace("/", "");
+        }
         return _name;
       },
       make_db: function() {
@@ -157,11 +165,12 @@
     }
   };
   Backbone.Collection = (function() {
-    function Collection() {
-      this._db_on_change = __bind(this._db_on_change, this);;
-      this._db_prepared_for_changes = __bind(this._db_prepared_for_changes, this);;      Collection.__super__.constructor.apply(this, arguments);
-    }
     __extends(Collection, Backbone.Collection);
+    function Collection() {
+      this._db_on_change = __bind(this._db_on_change, this);
+      this._db_prepared_for_changes = __bind(this._db_prepared_for_changes, this);
+      Collection.__super__.constructor.apply(this, arguments);
+    }
     Collection.prototype.initialize = function() {
       if (!this._db_changes_enabled && ((this.db && this.db.changes) || con.config.global_changes)) {
         return this.listen_to_changes();
@@ -213,10 +222,10 @@
     return Collection;
   })();
   Backbone.Model = (function() {
+    __extends(Model, Backbone.Model);
     function Model() {
       Model.__super__.constructor.apply(this, arguments);
     }
-    __extends(Model, Backbone.Model);
     Model.prototype.idAttribute = "_id";
     return Model;
   })();

--- a/backbone-couchdb.js
+++ b/backbone-couchdb.js
@@ -1,32 +1,30 @@
 (function() {
+
   /*
   (c) 2011 Jan Monschke
   v1.1
   backbone-couchdb.js is licensed under the MIT license.
   */
+
   var con;
-  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; }, __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) {
-    for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; }
-    function ctor() { this.constructor = child; }
-    ctor.prototype = parent.prototype;
-    child.prototype = new ctor;
-    child.__super__ = parent.prototype;
-    return child;
-  };
+  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; }, __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; };
+
   Backbone.couch_connector = con = {
     config: {
       db_name: "backbone_connect",
       ddoc_name: "backbone_example",
       view_name: "byCollection",
       global_changes: false,
+      single_feed: false,
       base_url: null
     },
+    _global_db_inst: null,
+    _global_changes_handler: null,
+    _global_changes_callbacks: [],
     helpers: {
       extract_collection_name: function(model) {
         var _name, _splitted;
-        if (model == null) {
-          throw new Error("No model has been passed");
-        }
+        if (model == null) throw new Error("No model has been passed");
         if (!(((model.collection != null) && (model.collection.url != null)) || (model.url != null))) {
           return "";
         }
@@ -35,20 +33,25 @@
         } else {
           _name = _.isFunction(model.collection.url) ? model.collection.url() : model.collection.url;
         }
-        if (_name[0] === "/") {
-          _name = _name.slice(1, _name.length);
-        }
+        if (_name[0] === "/") _name = _name.slice(1, _name.length);
         _splitted = _name.split("/");
         if (_splitted.length > 0) {
-          if (model.id === _splitted[_splitted.length - 1]) {
-            _splitted.pop();
-          }
+          if (model.id === _splitted[_splitted.length - 1]) _splitted.pop();
           _name = _splitted.join('/');
         }
-        if (_name.indexOf("/") === 0) {
-          _name = _name.replace("/", "");
-        }
+        if (_name.indexOf("/") === 0) _name = _name.replace("/", "");
         return _name;
+      },
+      filter_collection: function(results, collection_name) {
+        var entry, _i, _len, _ref, _results;
+        _results = [];
+        for (_i = 0, _len = results.length; _i < _len; _i++) {
+          entry = results[_i];
+          if ((entry.deleted === true) || (((_ref = entry.doc) != null ? _ref.collection : void 0) === collection_name)) {
+            _results.push(entry);
+          }
+        }
+        return _results;
       },
       make_db: function() {
         var db;
@@ -68,22 +71,19 @@
     },
     read_collection: function(coll, opts) {
       var keys, _opts, _view;
+      var _this = this;
       _view = this.config.view_name;
       keys = [this.helpers.extract_collection_name(coll)];
       if (coll.db != null) {
         if (coll.db.changes || this.config.global_changes) {
           coll.listen_to_changes();
         }
-        if (coll.db.view != null) {
-          _view = coll.db.view;
-        }
-        if (coll.db.keys != null) {
-          keys = coll.db.keys;
-        }
+        if (coll.db.view != null) _view = coll.db.view;
+        if (coll.db.keys != null) keys = coll.db.keys;
       }
       _opts = {
         keys: keys,
-        success: __bind(function(data) {
+        success: function(data) {
           var doc, _i, _len, _ref, _temp;
           _temp = [];
           _ref = data.rows;
@@ -92,7 +92,7 @@
             _temp.push(doc.value);
           }
           return opts.success(_temp);
-        }, this),
+        },
         error: function() {
           return opts.error();
         }
@@ -101,6 +101,41 @@
         delete _opts.keys;
       }
       return this.helpers.make_db().view("" + this.config.ddoc_name + "/" + _view, _opts);
+    },
+    init_global_changes_handler: function(callback) {
+      var _this = this;
+      this._global_db_inst = con.helpers.make_db();
+      return this._global_db_inst.info({
+        "success": function(data) {
+          var opts;
+          opts = _.extend({
+            include_docs: true
+          }, con.config.global_changes_opts);
+          _this._global_changes_handler = _this._global_db_inst.changes(data.update_seq || 0, opts);
+          _this._global_changes_handler.onChange(function(changes) {
+            var cb, _i, _len, _ref, _results;
+            _ref = _this._global_changes_callbacks;
+            _results = [];
+            for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+              cb = _ref[_i];
+              _results.push(cb(changes));
+            }
+            return _results;
+          });
+          return callback();
+        }
+      });
+    },
+    register_global_changes_callback: function(callback) {
+      var _this = this;
+      if (callback == null) return;
+      if (!(this._global_db_inst != null)) {
+        return this.init_global_changes_handler(function() {
+          return _this._global_changes_callbacks.push(callback);
+        });
+      } else {
+        return this._global_changes_callbacks.push(callback);
+      }
     },
     read_model: function(model, opts) {
       if (!model.id) {
@@ -119,9 +154,7 @@
       var coll, vals;
       vals = model.toJSON();
       coll = this.helpers.extract_collection_name(model);
-      if (coll.length > 0) {
-        vals.collection = coll;
-      }
+      if (coll.length > 0) vals.collection = coll;
       return this.helpers.make_db().saveDoc(vals, {
         success: function(doc) {
           return opts.success({
@@ -152,6 +185,7 @@
       });
     }
   };
+
   Backbone.sync = function(method, model, opts) {
     switch (method) {
       case "read":
@@ -164,29 +198,38 @@
         return con.del(model, opts);
     }
   };
+
   Backbone.Collection = (function() {
+
     __extends(Collection, Backbone.Collection);
+
     function Collection() {
       this._db_on_change = __bind(this._db_on_change, this);
+      this._db_prepared_for_global_changes = __bind(this._db_prepared_for_global_changes, this);
       this._db_prepared_for_changes = __bind(this._db_prepared_for_changes, this);
       Collection.__super__.constructor.apply(this, arguments);
     }
+
     Collection.prototype.initialize = function() {
       if (!this._db_changes_enabled && ((this.db && this.db.changes) || con.config.global_changes)) {
         return this.listen_to_changes();
       }
     };
+
     Collection.prototype.listen_to_changes = function() {
       if (!this._db_changes_enabled) {
         this._db_changes_enabled = true;
-        if (!this._db_inst) {
-          this._db_inst = con.helpers.make_db();
+        if (con.config.single_feed) {
+          return this._db_prepared_for_global_changes();
+        } else {
+          if (!this._db_inst) this._db_inst = con.helpers.make_db();
+          return this._db_inst.info({
+            "success": this._db_prepared_for_changes
+          });
         }
-        return this._db_inst.info({
-          "success": this._db_prepared_for_changes
-        });
       }
     };
+
     Collection.prototype.stop_changes = function() {
       this._db_changes_enabled = false;
       if (this._db_changes_handler != null) {
@@ -194,8 +237,10 @@
         return this._db_changes_handler = null;
       }
     };
+
     Collection.prototype._db_prepared_for_changes = function(data) {
       var opts;
+      var _this = this;
       this._db_update_seq = data.update_seq || 0;
       opts = {
         include_docs: true,
@@ -203,30 +248,65 @@
         filter: "" + con.config.ddoc_name + "/by_collection"
       };
       _.extend(opts, this.db);
-      return _.defer(__bind(function() {
-        this._db_changes_handler = this._db_inst.changes(this._db_update_seq, opts);
-        return this._db_changes_handler.onChange(this._db_on_change);
-      }, this));
+      return _.defer(function() {
+        _this._db_changes_handler = _this._db_inst.changes(_this._db_update_seq, opts);
+        return _this._db_changes_handler.onChange(_this._db_on_change);
+      });
     };
+
+    Collection.prototype._db_prepared_for_global_changes = function() {
+      return con.register_global_changes_callback(this._db_on_change);
+    };
+
     Collection.prototype._db_on_change = function(changes) {
-      var obj, _doc, _i, _len, _ref, _results;
-      _ref = changes.results;
+      var obj, results, _doc, _i, _len, _results;
+      results = changes.results;
+      if (this.db && this.db.local_filter) {
+        results = this.db.local_filter(results);
+      } else if (con.config.single_feed) {
+        results = con.helpers.filter_collection(results, con.helpers.extract_collection_name(this));
+      }
       _results = [];
-      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-        _doc = _ref[_i];
+      for (_i = 0, _len = results.length; _i < _len; _i++) {
+        _doc = results[_i];
         obj = this.get(_doc.id);
-        _results.push(obj != null ? _doc.deleted ? this.remove(obj) : obj.get("_rev") !== _doc.doc._rev ? obj.set(_doc.doc) : void 0 : !_doc.deleted ? this.add(_doc.doc) : void 0);
+        if (obj != null) {
+          if (_doc.deleted) {
+            _results.push(this.remove(obj));
+          } else {
+            if (obj.get("_rev") !== _doc.doc._rev) {
+              _results.push(obj.set(_doc.doc));
+            } else {
+              _results.push(void 0);
+            }
+          }
+        } else {
+          if (!_doc.deleted) {
+            _results.push(this.add(_doc.doc));
+          } else {
+            _results.push(void 0);
+          }
+        }
       }
       return _results;
     };
+
     return Collection;
+
   })();
+
   Backbone.Model = (function() {
+
     __extends(Model, Backbone.Model);
+
     function Model() {
       Model.__super__.constructor.apply(this, arguments);
     }
+
     Model.prototype.idAttribute = "_id";
+
     return Model;
+
   })();
+
 }).call(this);


### PR DESCRIPTION
This patch adds support for a single global changes feed (it also includes my previous patch for conservative collection name derivation, although that is trivial to separate).

The global feed is enabled like:

```
Backbone.couch_connector.config.single_feed = true;
```

When the single global feed is enabled, the way collection change handlers are registered is changed.  (_Whether_ they are registered has not been changed, and is still governed by the `global_changes` or individual collection `changes` setting.)

When single feed is enabled, each collection handler will be registered with a single changes feed.

Each collection also supports a `local_filter` irrespective of the single feed.  This `local_filter` function can be used to, you guessed it, filter change results from the changes feed.  When coupled with the single changes feed this allows each collection to only observe relevant changes.  When single feed is enabled, a default local filter is installed which does this (so if you follow standard conventions you should be able to just enable `single_feed`).

Default single_feed local_filter:

```
# default local filter which selects documents of a given collection
filter_collection : (results, collection_name) ->
  entry for entry in results when (entry.deleted == true) || (entry.doc?.collection == collection_name)
```

Example of custom local_filter:

```
var NoteList = Backbone.Collection.extend({
    url : "/notes",
    model: Note,
    db: {
        local_filter: function(results) {
          return _.filter(results, function(entry) { entry.doc.importance == "urgent" });
        }
    }
});
```

On a technical note, change listener registration could probably be factored out into a separate class that is reused for both the per-collection and global feed, but I wanted my changes to be minimal.
