### PR TITLE
Fix for "include_docs : true" when the view emits a null value 

### DIFF
--- a/backbone-couchdb.coffee
+++ b/backbone-couchdb.coffee
@@ -65,7 +65,7 @@ Backbone.couch_connector = con =
       success : (data) =>
         _temp = []
         for doc in data.rows
-          _temp.push doc.value
+          if doc.value then _temp.push doc.value else _temp.push doc.doc
         opts.success _temp
         opts.complete()
       error : ->

--- a/backbone-couchdb.js
+++ b/backbone-couchdb.js
@@ -1,4 +1,3 @@
-
 /*
 (c) 2011 Jan Monschke
 v1.1
@@ -73,7 +72,7 @@ backbone-couchdb.js is licensed under the MIT license.
           _ref = data.rows;
           for (_i = 0, _len = _ref.length; _i < _len; _i++) {
             doc = _ref[_i];
-            _temp.push(doc.value);
+            (doc.value) ? _temp.push(doc.value) : _temp.push(doc.doc);
           }
           opts.success(_temp);
           return opts.complete();


### PR DESCRIPTION
This fix handles the case where include_docs is true and the view emits only the key and null. When the view value is null we check to see if the doc exists in the returned data (as it will when include_docs is true) 

Example for a couchapp view with a complex key:
   "by_test_type_date" : {
        "map": "function (doc) { emit([doc.test_type, doc.created_at], null);}"
   }
