### PR TITLE
Fixes #36 - Add support for CouchDB lists

### DIFF
--- a/backbone-couchdb.coffee
+++ b/backbone-couchdb.coffee
@@ -61,6 +61,8 @@ Backbone.couch_connector = con =
         _view = coll.db.view
       if coll.db.keys?
         keys = coll.db.keys 
+      if coll.db.list?
+        _list = coll.db.list
     
     _opts = 
       keys : keys

--- a/backbone-couchdb.coffee
+++ b/backbone-couchdb.coffee
@@ -10,6 +10,7 @@ Backbone.couch_connector = con =
     db_name : "backbone_connect"
     ddoc_name : "backbone_example"
     view_name : "byCollection"
+    list_name : null
     # if true, all Collections will have the _changes feed enabled
     global_changes : false
     # change the databse base_url to be able to fetch from a remote couchdb
@@ -52,6 +53,7 @@ Backbone.couch_connector = con =
   # Reads all docs of a collection based on the byCollection view or a custom view specified by the collection
   read_collection : (coll, opts) ->
     _view = @config.view_name
+    _list = @config.list_name
     keys = [@helpers.extract_collection_name coll]
     if coll.db?
       coll.listen_to_changes() if coll.db.changes or @config.global_changes
@@ -98,7 +100,10 @@ Backbone.couch_connector = con =
     if coll.db? and coll.db.view? and not coll.db.keys?
       delete _opts.keys
     
-    @helpers.make_db().view "#{@config.ddoc_name}/#{_view}", _opts
+    if _list 
+      @helpers.make_db().list "#{@config.ddoc_name}/#{_list}", "#{_view}", _opts   
+    else
+      @helpers.make_db().view "#{@config.ddoc_name}/#{_view}", _opts    
 
 
   # Reads a model from the couchdb by it's ID 

--- a/backbone-couchdb.js
+++ b/backbone-couchdb.js
@@ -65,6 +65,7 @@ backbone-couchdb.js is licensed under the MIT license.
         }
         if (coll.db.view != null) _view = coll.db.view;
         if (coll.db.keys != null) keys = coll.db.keys;
+        if (coll.db.list != null) _list = coll.db.list;
       }
       _opts = {
         keys: keys,

--- a/backbone-couchdb.js
+++ b/backbone-couchdb.js
@@ -15,6 +15,7 @@ backbone-couchdb.js is licensed under the MIT license.
       db_name: "backbone_connect",
       ddoc_name: "backbone_example",
       view_name: "byCollection",
+      list_name: null,
       global_changes: false,
       base_url: null
     },
@@ -53,9 +54,10 @@ backbone-couchdb.js is licensed under the MIT license.
       }
     },
     read_collection: function(coll, opts) {
-      var keys, _opts, _view,
+      var keys, _opts, _view, _list,
         _this = this;
       _view = this.config.view_name;
+      _list = this.config.list_name;
       keys = [this.helpers.extract_collection_name(coll)];
       if (coll.db != null) {
         if (coll.db.changes || this.config.global_changes) {
@@ -92,7 +94,11 @@ backbone-couchdb.js is licensed under the MIT license.
       if ((coll.db != null) && (coll.db.view != null) && !(coll.db.keys != null)) {
         delete _opts.keys;
       }
-      return this.helpers.make_db().view("" + this.config.ddoc_name + "/" + _view, _opts);
+      if (_list != null) {
+        return this.helpers.make_db().list("" + this.config.ddoc_name + "/" + _list, "" + _view, _opts);
+      } else {
+        return this.helpers.make_db().view("" + this.config.ddoc_name + "/" + _view, _opts);
+      }
     },
     read_model: function(model, opts) {
       if (!model.id) {


### PR DESCRIPTION
If a list is specified in config.list_name or a collection's db.list attribute, the collection will be built based on the list.

If no list is specified, the collection is based on the specified view, as in the previous version.
