### PR TITLE
Allow collections to specify their own design document

### DIFF
--- a/backbone-couchdb.coffee
+++ b/backbone-couchdb.coffee
@@ -52,11 +52,14 @@ Backbone.couch_connector = con =
   # Reads all docs of a collection based on the byCollection view or a custom view specified by the collection
   read_collection : (coll, opts) ->
     _view = @config.view_name
+    _ddoc = @config.ddoc_name
     keys = [@helpers.extract_collection_name coll]
     if coll.db?
       coll.listen_to_changes() if coll.db.changes or @config.global_changes
       if coll.db.view?
         _view = coll.db.view
+      if coll.db.ddoc?
+        _ddoc = coll.db.ddoc
       if coll.db.keys?
         keys = coll.db.keys 
     
@@ -98,7 +101,7 @@ Backbone.couch_connector = con =
     if coll.db? and coll.db.view? and not coll.db.keys?
       delete _opts.keys
     
-    @helpers.make_db().view "#{@config.ddoc_name}/#{_view}", _opts
+    @helpers.make_db().view "#{_ddoc}/#{_view}", _opts
 
 
   # Reads a model from the couchdb by it's ID 

--- a/backbone-couchdb.js
+++ b/backbone-couchdb.js
@@ -53,15 +53,17 @@ backbone-couchdb.js is licensed under the MIT license.
       }
     },
     read_collection: function(coll, opts) {
-      var keys, _opts, _view,
+      var keys, _opts, _view, _ddoc,
         _this = this;
       _view = this.config.view_name;
+      _ddoc = this.config.ddoc_name;
       keys = [this.helpers.extract_collection_name(coll)];
       if (coll.db != null) {
         if (coll.db.changes || this.config.global_changes) {
           coll.listen_to_changes();
         }
         if (coll.db.view != null) _view = coll.db.view;
+        if (coll.db.ddoc != null) _ddoc = coll.db.ddoc;
         if (coll.db.keys != null) keys = coll.db.keys;
       }
       _opts = {
@@ -92,7 +94,7 @@ backbone-couchdb.js is licensed under the MIT license.
       if ((coll.db != null) && (coll.db.view != null) && !(coll.db.keys != null)) {
         delete _opts.keys;
       }
-      return this.helpers.make_db().view("" + this.config.ddoc_name + "/" + _view, _opts);
+      return this.helpers.make_db().view("" + _ddoc + "/" + _view, _opts);
     },
     read_model: function(model, opts) {
       if (!model.id) {


### PR DESCRIPTION
Much like we can specify a view other than "byCollection", this PRQ allows a collection to specify its own design document if it differs from the default.
