### PR TITLE
Support for single global changes feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ sync-behavior and connects your app to your
 [RELAX](http://vimeo.com/11852209) and don't need to worry about
 (real-time) server-side code.
 
+For a more detailed description head to [http://janmonschke.com/projects/backbone-couchdb.html](http://janmonschke.com/projects/backbone-couchdb.html).
+
 Demos
 -----
 * [Real time chat](http://backbone.iriscouch.com/backbone-couchapp/_design/backbone_example/index.html) with support for private messages. (source in `/chat_example`)
@@ -14,6 +16,20 @@ Demos
 
 Changelog
 ---------
+* 1.3
+  * Single global changes feed support to stay within the browser's concurrent connections per server limit [#25](https://github.com/janmonschke/backbone-couchdb/pull/25)
+
+* 1.2.2
+  * Revamped view options [#51](https://github.com/janmonschke/backbone-couchdb/pull/51)
+
+* 1.2
+  * CouchDB list support [#37](https://github.com/janmonschke/backbone-couchdb/pull/37)
+  * Support for custom design documents for collections [#38](https://github.com/janmonschke/backbone-couchdb/pull/38)
+  * Fix for views that emit `null` [#35](https://github.com/janmonschke/backbone-couchdb/pull/35)
+  * A better way to test the library [/test](https://github.com/janmonschke/backbone-couchdb/tree/master/test)
+  * more request information in error callbacks [#20](https://github.com/janmonschke/backbone-couchdb/issues/20#issuecomment-5461404)
+  * Support for more options when fetching a collection [#34](https://github.com/janmonschke/backbone-couchdb/pull/34)
+  * tested with Backbone 0.9.2
 
 * 1.1
   * Fixed a bug with empty key param
@@ -25,78 +41,3 @@ Changelog
   * Backbone 5.1 support
   * Various bugfixes
   * Started versioning ;)
-  
-Dependencies (already included in the examples)
-------------
-
-* [Backbone.js](https://github.com/documentcloud/backbone) (>= 0.5.1)
-* [Underscore.js](https://github.com/documentcloud/underscore)
-* [jquery.couch.js](https://github.com/apache/couchdb/blob/trunk/share/www/script/jquery.couch.js)
-* [jQuery](http://www.jquery.com/)
-
-Why a new connector?
---------------------
-
-I developed this connector because I didn't want to write a whole new
-server that persists the models that Backbone.js creates. Instead of
-writing a server you now only have to write a simple design document
-containing one simple view and you're done with server-side code and can
-fully concentrate on the Backbone App.
-
-Also I wanted to get real time updates when my models are changed on the
-server (e.g. by a second user). The CouchDB _changes feed seemed like a
-perfect match for this problem.
-
-Getting Started
----------------
-
-All Backbone apps should work normally without any changes. Simply
-include `backbone-couchdb.js` with its dependencies into your project
-and configure the connector with your database infos.
-
-    Backbone.couch_connector.config.db_name = "backbone-couchapp";
-    Backbone.couch_connector.config.ddoc_name = "backbone-couchapp";
-    Backbone.couch_connector.config.global_changes = false;
-	
-As you can see you also need to create a new database in your CouchDB
-and a new design document that contains the following view:
-
-    function(doc) {
-        if (doc.collection) {
-            emit(doc.collection, doc);
-        }
-    }
-
-If you set `Backbone.couch_connector.config.global_changes` to true, the
-connector will automatically update your models with remote changes in
-near real time.
-
-Give your [couchapp](https://github.com/couchapp/couchapp) some backbone
-------------------------------------------------------------------------
-
-An easy way to host single-page apps is to enclose them in a couchapp. I
-included a sample couchapp project (`/chat_example`) to show you how to
-create couchapps with Backbone and this CouchDB connector. You can also
-use it as a bare couchapp directory structure for new projects.
-
-There is an instance of this couchapp running on [iriscouch.com
-(demo)](http://backbone.iriscouch.com/backbone-couchapp/_design/backbone_example/index.html)
-and I uploaded a file with the [annotated
-source](http://janmonschke.github.com/backbone-couchdb/app.html) of the
-app. (Created with [docco](https://github.com/jashkenas/docco))
-
-Erica support
--------------
-
-[Erica](http://github.com/benoitc/erica) templates are supported. Simply
-link the backbone-couchdb folder to ~/.erica/templates. Then you can
-create an application using these templates:
-
-    $ erica create template=backbone appid=myappname
-
-Learn more
-----------
-
-To show how backbone-couchdb works under the hood I created an annotated
-source file located
-[here](http://janmonschke.github.com/backbone-couchdb/backbone-couchdb.html).

--- a/backbone-couchdb.coffee
+++ b/backbone-couchdb.coffee
@@ -31,8 +31,17 @@ Backbone.couch_connector = con =
       # jquery.couch.js adds the id itself, so we delete the id if it is in the url.
       # "collection/:id" -> "collection"
       _splitted = _name.split "/"
-      _name = if _splitted.length > 0 then _splitted[0] else _name
-      _name = _name.replace "/", ""
+
+      # only pop off the last component if it is the id
+      if (_splitted.length > 0)
+        if (model.id == _splitted[_splitted.length - 1])
+          _splitted.pop()
+        _name = _splitted.join('/')
+
+      # remove any leading slash
+      if (_name.indexOf("/") == 0)
+        _name = _name.replace("/", "")
+
       _name
     
     # creates a database instance from the 

--- a/backbone-couchdb.coffee
+++ b/backbone-couchdb.coffee
@@ -39,8 +39,16 @@ Backbone.couch_connector = con =
       # jquery.couch.js adds the id itself, so we delete the id if it is in the url.
       # "collection/:id" -> "collection"
       _splitted = _name.split "/"
-      _name = if _splitted.length > 0 then _splitted[0] else _name
-      _name = _name.replace "/", ""
+
+      # only pop off the last component if it is the id
+      if (_splitted.length > 0)
+        if (model.id == _splitted[_splitted.length - 1])
+          _splitted.pop()
+        _name = _splitted.join('/')
+
+      # remove any leading slash
+      if (_name.indexOf("/") == 0)
+        _name = _name.replace("/", "")
       _name
     
     # default local filter which selects documents of a given collection

--- a/backbone-couchdb.js
+++ b/backbone-couchdb.js
@@ -1,9 +1,10 @@
 (function() {
   /*
   (c) 2011 Jan Monschke
-  v1.0
+  v1.1
   backbone-couchdb.js is licensed under the MIT license.
-  */  var con;
+  */
+  var con;
   var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; }, __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) {
     for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; }
     function ctor() { this.constructor = child; }
@@ -38,8 +39,15 @@
           _name = _name.slice(1, _name.length);
         }
         _splitted = _name.split("/");
-        _name = _splitted.length > 0 ? _splitted[0] : _name;
-        _name = _name.replace("/", "");
+        if (_splitted.length > 0) {
+          if (model.id === _splitted[_splitted.length - 1]) {
+            _splitted.pop();
+          }
+          _name = _splitted.join('/');
+        }
+        if (_name.indexOf("/") === 0) {
+          _name = _name.replace("/", "");
+        }
         return _name;
       },
       make_db: function() {
@@ -157,11 +165,12 @@
     }
   };
   Backbone.Collection = (function() {
-    function Collection() {
-      this._db_on_change = __bind(this._db_on_change, this);;
-      this._db_prepared_for_changes = __bind(this._db_prepared_for_changes, this);;      Collection.__super__.constructor.apply(this, arguments);
-    }
     __extends(Collection, Backbone.Collection);
+    function Collection() {
+      this._db_on_change = __bind(this._db_on_change, this);
+      this._db_prepared_for_changes = __bind(this._db_prepared_for_changes, this);
+      Collection.__super__.constructor.apply(this, arguments);
+    }
     Collection.prototype.initialize = function() {
       if (!this._db_changes_enabled && ((this.db && this.db.changes) || con.config.global_changes)) {
         return this.listen_to_changes();
@@ -213,10 +222,10 @@
     return Collection;
   })();
   Backbone.Model = (function() {
+    __extends(Model, Backbone.Model);
     function Model() {
       Model.__super__.constructor.apply(this, arguments);
     }
-    __extends(Model, Backbone.Model);
     Model.prototype.idAttribute = "_id";
     return Model;
   })();

--- a/backbone-couchdb.js
+++ b/backbone-couchdb.js
@@ -1,32 +1,30 @@
 (function() {
+
   /*
   (c) 2011 Jan Monschke
   v1.1
   backbone-couchdb.js is licensed under the MIT license.
   */
+
   var con;
-  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; }, __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) {
-    for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; }
-    function ctor() { this.constructor = child; }
-    ctor.prototype = parent.prototype;
-    child.prototype = new ctor;
-    child.__super__ = parent.prototype;
-    return child;
-  };
+  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; }, __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; };
+
   Backbone.couch_connector = con = {
     config: {
       db_name: "backbone_connect",
       ddoc_name: "backbone_example",
       view_name: "byCollection",
       global_changes: false,
+      single_feed: false,
       base_url: null
     },
+    _global_db_inst: null,
+    _global_changes_handler: null,
+    _global_changes_callbacks: [],
     helpers: {
       extract_collection_name: function(model) {
         var _name, _splitted;
-        if (model == null) {
-          throw new Error("No model has been passed");
-        }
+        if (model == null) throw new Error("No model has been passed");
         if (!(((model.collection != null) && (model.collection.url != null)) || (model.url != null))) {
           return "";
         }
@@ -35,20 +33,25 @@
         } else {
           _name = _.isFunction(model.collection.url) ? model.collection.url() : model.collection.url;
         }
-        if (_name[0] === "/") {
-          _name = _name.slice(1, _name.length);
-        }
+        if (_name[0] === "/") _name = _name.slice(1, _name.length);
         _splitted = _name.split("/");
         if (_splitted.length > 0) {
-          if (model.id === _splitted[_splitted.length - 1]) {
-            _splitted.pop();
-          }
+          if (model.id === _splitted[_splitted.length - 1]) _splitted.pop();
           _name = _splitted.join('/');
         }
-        if (_name.indexOf("/") === 0) {
-          _name = _name.replace("/", "");
-        }
+        if (_name.indexOf("/") === 0) _name = _name.replace("/", "");
         return _name;
+      },
+      filter_collection: function(results, collection_name) {
+        var entry, _i, _len, _ref, _results;
+        _results = [];
+        for (_i = 0, _len = results.length; _i < _len; _i++) {
+          entry = results[_i];
+          if ((entry.deleted === true) || (((_ref = entry.doc) != null ? _ref.collection : void 0) === collection_name)) {
+            _results.push(entry);
+          }
+        }
+        return _results;
       },
       make_db: function() {
         var db;
@@ -68,22 +71,19 @@
     },
     read_collection: function(coll, opts) {
       var keys, _opts, _view;
+      var _this = this;
       _view = this.config.view_name;
       keys = [this.helpers.extract_collection_name(coll)];
       if (coll.db != null) {
         if (coll.db.changes || this.config.global_changes) {
           coll.listen_to_changes();
         }
-        if (coll.db.view != null) {
-          _view = coll.db.view;
-        }
-        if (coll.db.keys != null) {
-          keys = coll.db.keys;
-        }
+        if (coll.db.view != null) _view = coll.db.view;
+        if (coll.db.keys != null) keys = coll.db.keys;
       }
       _opts = {
         keys: keys,
-        success: __bind(function(data) {
+        success: function(data) {
           var doc, _i, _len, _ref, _temp;
           _temp = [];
           _ref = data.rows;
@@ -92,7 +92,7 @@
             _temp.push(doc.value);
           }
           return opts.success(_temp);
-        }, this),
+        },
         error: function() {
           return opts.error();
         }
@@ -101,6 +101,41 @@
         delete _opts.keys;
       }
       return this.helpers.make_db().view("" + this.config.ddoc_name + "/" + _view, _opts);
+    },
+    init_global_changes_handler: function(callback) {
+      var _this = this;
+      this._global_db_inst = con.helpers.make_db();
+      return this._global_db_inst.info({
+        "success": function(data) {
+          var opts;
+          opts = _.extend({
+            include_docs: true
+          }, con.config.global_changes_opts);
+          _this._global_changes_handler = _this._global_db_inst.changes(data.update_seq || 0, opts);
+          _this._global_changes_handler.onChange(function(changes) {
+            var cb, _i, _len, _ref, _results;
+            _ref = _this._global_changes_callbacks;
+            _results = [];
+            for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+              cb = _ref[_i];
+              _results.push(cb(changes));
+            }
+            return _results;
+          });
+          return callback();
+        }
+      });
+    },
+    register_global_changes_callback: function(callback) {
+      var _this = this;
+      if (callback == null) return;
+      if (!(this._global_db_inst != null)) {
+        return this.init_global_changes_handler(function() {
+          return _this._global_changes_callbacks.push(callback);
+        });
+      } else {
+        return this._global_changes_callbacks.push(callback);
+      }
     },
     read_model: function(model, opts) {
       if (!model.id) {
@@ -119,9 +154,7 @@
       var coll, vals;
       vals = model.toJSON();
       coll = this.helpers.extract_collection_name(model);
-      if (coll.length > 0) {
-        vals.collection = coll;
-      }
+      if (coll.length > 0) vals.collection = coll;
       return this.helpers.make_db().saveDoc(vals, {
         success: function(doc) {
           return opts.success({
@@ -152,6 +185,7 @@
       });
     }
   };
+
   Backbone.sync = function(method, model, opts) {
     switch (method) {
       case "read":
@@ -164,29 +198,38 @@
         return con.del(model, opts);
     }
   };
+
   Backbone.Collection = (function() {
+
     __extends(Collection, Backbone.Collection);
+
     function Collection() {
       this._db_on_change = __bind(this._db_on_change, this);
+      this._db_prepared_for_global_changes = __bind(this._db_prepared_for_global_changes, this);
       this._db_prepared_for_changes = __bind(this._db_prepared_for_changes, this);
       Collection.__super__.constructor.apply(this, arguments);
     }
+
     Collection.prototype.initialize = function() {
       if (!this._db_changes_enabled && ((this.db && this.db.changes) || con.config.global_changes)) {
         return this.listen_to_changes();
       }
     };
+
     Collection.prototype.listen_to_changes = function() {
       if (!this._db_changes_enabled) {
         this._db_changes_enabled = true;
-        if (!this._db_inst) {
-          this._db_inst = con.helpers.make_db();
+        if (con.config.single_feed) {
+          return this._db_prepared_for_global_changes();
+        } else {
+          if (!this._db_inst) this._db_inst = con.helpers.make_db();
+          return this._db_inst.info({
+            "success": this._db_prepared_for_changes
+          });
         }
-        return this._db_inst.info({
-          "success": this._db_prepared_for_changes
-        });
       }
     };
+
     Collection.prototype.stop_changes = function() {
       this._db_changes_enabled = false;
       if (this._db_changes_handler != null) {
@@ -194,8 +237,10 @@
         return this._db_changes_handler = null;
       }
     };
+
     Collection.prototype._db_prepared_for_changes = function(data) {
       var opts;
+      var _this = this;
       this._db_update_seq = data.update_seq || 0;
       opts = {
         include_docs: true,
@@ -203,30 +248,65 @@
         filter: "" + con.config.ddoc_name + "/by_collection"
       };
       _.extend(opts, this.db);
-      return _.defer(__bind(function() {
-        this._db_changes_handler = this._db_inst.changes(this._db_update_seq, opts);
-        return this._db_changes_handler.onChange(this._db_on_change);
-      }, this));
+      return _.defer(function() {
+        _this._db_changes_handler = _this._db_inst.changes(_this._db_update_seq, opts);
+        return _this._db_changes_handler.onChange(_this._db_on_change);
+      });
     };
+
+    Collection.prototype._db_prepared_for_global_changes = function() {
+      return con.register_global_changes_callback(this._db_on_change);
+    };
+
     Collection.prototype._db_on_change = function(changes) {
-      var obj, _doc, _i, _len, _ref, _results;
-      _ref = changes.results;
+      var obj, results, _doc, _i, _len, _results;
+      results = changes.results;
+      if (this.db && this.db.local_filter) {
+        results = this.db.local_filter(results);
+      } else if (con.config.single_feed) {
+        results = con.helpers.filter_collection(results, con.helpers.extract_collection_name(this));
+      }
       _results = [];
-      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-        _doc = _ref[_i];
+      for (_i = 0, _len = results.length; _i < _len; _i++) {
+        _doc = results[_i];
         obj = this.get(_doc.id);
-        _results.push(obj != null ? _doc.deleted ? this.remove(obj) : obj.get("_rev") !== _doc.doc._rev ? obj.set(_doc.doc) : void 0 : !_doc.deleted ? this.add(_doc.doc) : void 0);
+        if (obj != null) {
+          if (_doc.deleted) {
+            _results.push(this.remove(obj));
+          } else {
+            if (obj.get("_rev") !== _doc.doc._rev) {
+              _results.push(obj.set(_doc.doc));
+            } else {
+              _results.push(void 0);
+            }
+          }
+        } else {
+          if (!_doc.deleted) {
+            _results.push(this.add(_doc.doc));
+          } else {
+            _results.push(void 0);
+          }
+        }
       }
       return _results;
     };
+
     return Collection;
+
   })();
+
   Backbone.Model = (function() {
+
     __extends(Model, Backbone.Model);
+
     function Model() {
       Model.__super__.constructor.apply(this, arguments);
     }
+
     Model.prototype.idAttribute = "_id";
+
     return Model;
+
   })();
+
 }).call(this);


### PR DESCRIPTION
This pull request attempts to finish the work done in https://github.com/janmonschke/backbone-couchdb/pull/25, titled "Support for single global changes feed."

Here is what I did:

I merged backbone-couchdb.coffee version 1.2.2 into version 1.1 as modified in pull request #25's changes at https://github.com/janmonschke/backbone-couchdb/pull/25, and updated README.md accordingly as requested by Jan in https://github.com/janmonschke/backbone-couchdb/pull/25#issuecomment-3437964.

I did not update the generated backbone-couchdb.js file (because I ran into an error saying Backbone was not declared and didn't know how to properly import it in the build process), docs (because I don't want to take the time to learn docco if someone else already has the ability to run it quickly), tests (because I couldn't generate the .js file and am unsure how to test the new features) or example app (because I couldn't generate the .js file).  Jan, or someone else, could you do these tasks and then release a new version of backbone-couchdb?  Thank you!
