### PR TITLE
Override Backbone.Model.clone correctly

### DIFF
--- a/backbone-couchdb.coffee
+++ b/backbone-couchdb.coffee
@@ -228,7 +228,7 @@ class Backbone.Model extends Backbone.Model
   # change the idAttribute since CouchDB uses _id
   idAttribute : "_id"
   clone : ->
-    new_model = new @constructor(@)
+    new_model = new @constructor(@attributes)
     # remove _id and _rev attributes on the cloned model object to have a **really** new, unsaved model object.
     # _id and _rev only exist on objects that have been saved, so check for existence is needed.
     delete new_model.attributes._id if new_model.attributes._id


### PR DESCRIPTION
This has been a mistake for a long time but it seems that older versions of Backbone have been more forgiving.

An older backbone where we were lucky it worked with backbone-couchdb.js: https://github.com/jashkenas/backbone/blob/0.9.2/backbone.js#L450

A recent backbone Backbone.Model.clone where we get weird results when using backbone-couchdb.js: https://github.com/jashkenas/backbone/blob/1.2.3/backbone.js#L707

The forgiveness happens in the constructor. Even if it used to work when used incorrectly, it definitely doesn't work now and this needs to be fixed.
